### PR TITLE
Fix wrong empty check

### DIFF
--- a/core/components/getdynadescription/elements/snippets/getdynadescription.snippet.php
+++ b/core/components/getdynadescription/elements/snippets/getdynadescription.snippet.php
@@ -46,7 +46,7 @@
 /* getdynadescription snippet code */
 
 /* Can't see why anyone would want this, but it's in the original snippet - BR */
-if ( empty($scriptProperties['resourceId'])) {
+if (!empty($scriptProperties['resourceId'])) {
     $resource = $modx->getObject('modResource', $scriptProperties['resourceId']);
     if (! $resource) {
         return '';


### PR DESCRIPTION
I had an issue with that code part in MODX3. $scriptProperties['resourceId'] is empty by default and seems to have be used inverted.